### PR TITLE
fix installations of icons on fbreader for desktops

### DIFF
--- a/fbreader/Makefile
+++ b/fbreader/Makefile
@@ -60,8 +60,8 @@ do_install:
 	@install -d $(FBSHAREDIR)/resources
 	@install -m 0644 $(wildcard data/resources/*.xml) $(FBSHAREDIR)/resources
 	@install -d $(DESTDIR)$(APPIMAGEDIR_REAL)
-	@install -m 0644 $(wildcard data/icons/toolbar/$(VARIANT)/*.*) $(DESTDIR)$(APPIMAGEDIR_REAL)
-	@install -m 0644 $(wildcard data/icons/filetree/$(VARIANT)/*.*) $(DESTDIR)$(APPIMAGEDIR_REAL)
+	@install -m 0644 $(wildcard data/icons/toolbar/$(TARGET_ARCH)/*.*) $(DESTDIR)$(APPIMAGEDIR_REAL)
+	@install -m 0644 $(wildcard data/icons/filetree/$(TARGET_ARCH)/*.*) $(DESTDIR)$(APPIMAGEDIR_REAL)
 	@install -m 0644 $(wildcard data/icons/booktree/new/*.*) $(DESTDIR)$(APPIMAGEDIR_REAL)
 	@make -C $(TARGET_ARCH) RESOLUTION=$(RESOLUTION) install
 


### PR DESCRIPTION
When resolution is set, the following code(in fbreader/Makefile) is executed:
  VARIANT = $(TARGET_ARCH)
  ifneq "$(RESOLUTION)" ""
    VARIANT = $(TARGET_ARCH)_$(RESOLUTION)
  endif

This fix is based on a patch from the openembedded project,
  which can be found here:
    http://cgit.openembedded.org/openembedded/tree/recipes/fbreader/fbreader-0.12.1/Makefile.patch

Signed-off-by: Denis 'GNUtoo' Carikli GNUtoo@no-log.org
