### PR TITLE
Fixed several errors provided by gcc warnings

### DIFF
--- a/fbreader/src/bookmodel/BookModel.h
+++ b/fbreader/src/bookmodel/BookModel.h
@@ -55,6 +55,7 @@ public:
 	class HyperlinkMatcher {
 
 	public:
+		virtual ~HyperlinkMatcher() {}
 		virtual Label match(const std::map<std::string,Label> &lMap, const std::string &id) const = 0;
 	};
 

--- a/fbreader/src/database/booksdb/BooksDB.cpp
+++ b/fbreader/src/database/booksdb/BooksDB.cpp
@@ -145,7 +145,7 @@ shared_ptr<Book> BooksDB::loadBook(const std::string &fileName) {
 
 	myFindFileId->setFileName(fileName);
 	if (!myFindFileId->run()) {
-		return false;
+		return 0;
 	}
 	((DBIntValue&)*myLoadBook->parameter("@file_id").value()) = myFindFileId->fileId();
 	shared_ptr<DBDataReader> reader = myLoadBook->executeReader();

--- a/fbreader/src/network/BookReference.h
+++ b/fbreader/src/network/BookReference.h
@@ -44,6 +44,7 @@ public:
 
 public:
 	BookReference(const std::string &url, Format format, Type type);
+	virtual ~BookReference() {}
 
 public:
 	const std::string URL;

--- a/zlibrary/core/src/dialogs/ZLOpenFileDialog.h
+++ b/zlibrary/core/src/dialogs/ZLOpenFileDialog.h
@@ -35,6 +35,7 @@ public:
 	};
 
 public:
+	virtual ~ZLOpenFileDialog() {}
 	virtual bool run() = 0;
 	virtual std::string filePath() const = 0;
 	virtual std::string directoryPath() const = 0;

--- a/zlibrary/core/src/language/ZLStatisticsItem.cpp
+++ b/zlibrary/core/src/language/ZLStatisticsItem.cpp
@@ -38,9 +38,9 @@ void ZLMapBasedStatisticsItem::next() {
 
 ZLArrayBasedStatisticsItem::ZLArrayBasedStatisticsItem(size_t sequenceLength, char* sequencePtr, unsigned short* frequencyPtr, size_t index) :
 	ZLStatisticsItem(index),
-	mySequenceLength(sequenceLength),
 	mySequencePtr(sequencePtr), 
-	myFrequencyPtr(frequencyPtr) {
+	myFrequencyPtr(frequencyPtr),
+	mySequenceLength(sequenceLength) {
 }
 
 ZLCharSequence ZLArrayBasedStatisticsItem::sequence() const {


### PR DESCRIPTION
Really, virtual destructors are good way to avoid memory leaks :)
