### PR TITLE
Added key shortcuts to Desktop build for quit and forceQuit commands

### DIFF
--- a/fbreader/data/default/keymap.desktop.xml
+++ b/fbreader/data/default/keymap.desktop.xml
@@ -30,6 +30,8 @@
 	<binding key="&lt;R&gt;" action="rotate"/>
 	<binding key="&lt;Ctrl&gt;+&lt;DownArrow&gt;" action="nextTOCSection"/>
 	<binding key="&lt;Ctrl&gt;+&lt;UpArrow&gt;" action="previousTOCSection"/>
+	<binding key="&lt;Command&gt;+&lt;Q&gt;" action="forceQuit"/>
+	<binding key="&lt;Command&gt;+&lt;W&gt;" action="quit"/>
 	<binding key="&lt;Ctrl&gt;+&lt;C&gt;" action="copyToClipboard"/>
 	<binding key="&lt;G&gt;" action="gotoPageNumber"/>
 	<binding key="&lt;Z&gt;" action="debugNL"/>


### PR DESCRIPTION
I'm a bit puzzled as to why FBReader would not include default keyboard shortcuts for closing the program on GNU/Linux systems (among others). The ones I added are those most commonly found in modern applications (such as other document readers like Evince or web browsers) and apparently already available in the Mac OS build.