### PR TITLE
Handle null values

### DIFF
--- a/zlibrary/core/src/filesystem/tar/ZLTar.cpp
+++ b/zlibrary/core/src/filesystem/tar/ZLTar.cpp
@@ -193,6 +193,7 @@ size_t ZLTarInputStream::sizeOfOpened() {
 
 void ZLTarDir::collectFiles(std::vector<std::string> &names, bool) {
 	shared_ptr<ZLInputStream> stream = ZLFile(path()).inputStream();
+	if (stream == 0) return;
 	const ZLTarHeaderCache &cache = ZLTarHeaderCache::cache(*stream);
 	cache.collectFileNames(names);
 }

--- a/zlibrary/core/src/filesystem/zip/ZLZipDir.cpp
+++ b/zlibrary/core/src/filesystem/zip/ZLZipDir.cpp
@@ -23,6 +23,7 @@
 
 void ZLZipDir::collectFiles(std::vector<std::string> &names, bool) {
 	shared_ptr<ZLInputStream> stream = ZLFile(path()).inputStream();
+	if (stream == 0) return;
 	const ZLZipEntryCache &cache = ZLZipEntryCache::cache(*stream);
 	cache.collectFileNames(names);
 }


### PR DESCRIPTION
Avoid segfaults on badly detected files.

Currently inputstream returns null on directories, and probably in unreadable
files.

This small change skips those.