### PR TITLE
BooksDB.cpp:148:10: error: could not convert ‘false’ from ‘bool’ to ‘…

### DIFF
--- a/fbreader/src/database/booksdb/BooksDB.cpp
+++ b/fbreader/src/database/booksdb/BooksDB.cpp
@@ -145,7 +145,7 @@ shared_ptr<Book> BooksDB::loadBook(const std::string &fileName) {
 
 	myFindFileId->setFileName(fileName);
 	if (!myFindFileId->run()) {
-		return false;
+		return 0;
 	}
 	((DBIntValue&)*myLoadBook->parameter("@file_id").value()) = myFindFileId->fileId();
 	shared_ptr<DBDataReader> reader = myLoadBook->executeReader();


### PR DESCRIPTION
…shared_ptr<Book>’

```
Compiling BooksDB.o ...BooksDB.cpp: In member function ‘shared_ptr<Book> BooksDB::loadBook(const string&)’:
BooksDB.cpp:148:10: error: could not convert ‘false’ from ‘bool’ to ‘shared_ptr<Book>’
   return false;
          ^~~~~
```

```
$ gcc --version
gcc (GCC) 6.3.0
Copyright (C) 2016 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```