### PR TITLE
Fix Curl constant

### DIFF
--- a/zlibrary/core/src/unix/curl/ZLCurlNetworkManager.cpp
+++ b/zlibrary/core/src/unix/curl/ZLCurlNetworkManager.cpp
@@ -285,9 +285,11 @@ std::string ZLCurlNetworkManager::perform(const ZLExecutionData::Vector &dataLis
 #endif
 					errors.insert(ZLStringUtil::printf(errorResource["peerFailedVerificationMessage"].value(), ZLNetworkUtil::hostFromUrl(url)));
 					break;
+#if LIBCURL_VERSION_NUM < 0x073000
 				case CURLE_SSL_CACERT:
 					errors.insert(ZLStringUtil::printf(errorResource["sslCertificateAuthorityMessage"].value(), ZLNetworkUtil::hostFromUrl(url)));
 					break;
+#endif
 				case CURLE_SSL_CACERT_BADFILE:
 					errors.insert(ZLStringUtil::printf(errorResource["sslBadCertificateFileMessage"].value(), request.sslCertificate().Path));
 					break;


### PR DESCRIPTION
The compiler was throwing an error because these constants have the same
value, and represent a duplicate case value.

Seen when compiling against curl 7.68. using GCC 9.2.0 on Linux.