### PR TITLE
Fix return type

### DIFF
--- a/fbreader/src/database/booksdb/BooksDB.cpp
+++ b/fbreader/src/database/booksdb/BooksDB.cpp
@@ -145,7 +145,7 @@ shared_ptr<Book> BooksDB::loadBook(const std::string &fileName) {
 
 	myFindFileId->setFileName(fileName);
 	if (!myFindFileId->run()) {
-		return false;
+		return 0;
 	}
 	((DBIntValue&)*myLoadBook->parameter("@file_id").value()) = myFindFileId->fileId();
 	shared_ptr<DBDataReader> reader = myLoadBook->executeReader();


### PR DESCRIPTION
GCC won't let you return a bool when the return type is `shared_ptr<Book>`. Closest we can get to an error condition is NULL.