### PR TITLE
Fix icon name

### DIFF
--- a/fbreader/desktop/desktop
+++ b/fbreader/desktop/desktop
@@ -25,5 +25,5 @@ Exec=FBReader %F
 StartupNotify=true
 Terminal=false
 Type=Application
-Icon=FBReader.png
+Icon=FBReader
 Categories=Office;Viewer;Literature;


### PR DESCRIPTION
Often GTK icons packs will have a scalable (SVG) version of the icon installed in `/usr/share/icons/hicolor/scalable/apps/FBReader.svg` for example.

See here: https://wiki.archlinux.org/index.php/Desktop_entries