### PR TITLE
nits for compatibility with Ubuntu Focal Fossa

### DIFF
--- a/fbreader/src/database/booksdb/BooksDB.cpp
+++ b/fbreader/src/database/booksdb/BooksDB.cpp
@@ -62,7 +62,7 @@ bool BooksDB::initDatabase() {
 
 	if (!open()) {
 		return false;
-	} 
+	}
 
 	myInitialized = true;
 
@@ -145,7 +145,7 @@ shared_ptr<Book> BooksDB::loadBook(const std::string &fileName) {
 
 	myFindFileId->setFileName(fileName);
 	if (!myFindFileId->run()) {
-		return false;
+		return 0;
 	}
 	((DBIntValue&)*myLoadBook->parameter("@file_id").value()) = myFindFileId->fileId();
 	shared_ptr<DBDataReader> reader = myLoadBook->executeReader();
@@ -440,7 +440,7 @@ bool BooksDB::setNetFile(const std::string &url, const std::string &fileName) {
 		"INSERT OR REPLACE INTO NetFiles (url, file_id) VALUES (@url, @file_id);",
 		connection(), "@file_id", DBValue::DBINT, "@url", DBValue::DBTEXT
 	);
-	
+
 	myFindFileId->setFileName(fileName, true);
 	if (!myFindFileId->run()) {
 		return false;

--- a/fbreader/src/network/BookReference.cpp
+++ b/fbreader/src/network/BookReference.cpp
@@ -25,6 +25,9 @@
 BookReference::BookReference(const std::string &url, Format format, Type type) : URL(url), BookFormat(format), ReferenceType(type) {
 }
 
+BookReference::~BookReference(){
+}
+
 const std::string &BookReference::cleanURL() const {
 	return URL;
 }

--- a/fbreader/src/network/BookReference.h
+++ b/fbreader/src/network/BookReference.h
@@ -44,6 +44,7 @@ public:
 
 public:
 	BookReference(const std::string &url, Format format, Type type);
+	virtual ~BookReference();
 
 public:
 	const std::string URL;

--- a/zlibrary/core/src/unix/curl/ZLCurlNetworkManager.cpp
+++ b/zlibrary/core/src/unix/curl/ZLCurlNetworkManager.cpp
@@ -285,9 +285,11 @@ std::string ZLCurlNetworkManager::perform(const ZLExecutionData::Vector &dataLis
 #endif
 					errors.insert(ZLStringUtil::printf(errorResource["peerFailedVerificationMessage"].value(), ZLNetworkUtil::hostFromUrl(url)));
 					break;
+#if LIBCURL_VERSION_NUM < 0x074400
 				case CURLE_SSL_CACERT:
 					errors.insert(ZLStringUtil::printf(errorResource["sslCertificateAuthorityMessage"].value(), ZLNetworkUtil::hostFromUrl(url)));
 					break;
+#endif
 				case CURLE_SSL_CACERT_BADFILE:
 					errors.insert(ZLStringUtil::printf(errorResource["sslBadCertificateFileMessage"].value(), request.sslCertificate().Path));
 					break;


### PR DESCRIPTION
I wanted to compile FBReader using a laptop with recent Ubuntu Focal Fossa. I found a new nits have to be fixed to compile FBReader from master:
- in recent curllib
./x86_64-linux-gnu/curl/curl.h:630:#define CURLE_SSL_CACERT CURLE_PEER_FAILED_VERIFICATION
- gcc is a little bit more pedantic